### PR TITLE
Add GitHub star banner and theme preference functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@faker-js/faker": "^9.9.0",
+        "@radix-ui/react-icons": "^1.3.2",
         "@radix-ui/themes": "^3.2.1",
         "@react-pdf/renderer": "^4.3.0",
         "@types/node": "^24.2.1",
@@ -1241,6 +1242,15 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@radix-ui/react-icons": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-icons/-/react-icons-1.3.2.tgz",
+      "integrity": "sha512-fyQIhGDhzfc9pK2kH6Pl9c4BDJGfMkPqkyIgYDthyNYoNg3wVhoJMMh19WS4Up/1KMPFVpNsT2q3WmXn2N1m6g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.x || ^17.x || ^18.x || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/@radix-ui/react-id": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "^9.9.0",
+    "@radix-ui/react-icons": "^1.3.2",
     "@radix-ui/themes": "^3.2.1",
     "@react-pdf/renderer": "^4.3.0",
     "@types/node": "^24.2.1",

--- a/src/App.css
+++ b/src/App.css
@@ -1,3 +1,23 @@
+/* GitHub Star Banner */
+.github-star-banner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 32px;
+  background: linear-gradient(90deg, #833ab4, #fd1d1d 50%, #fcb045);
+  color: white;
+  text-align: center;
+  text-decoration: none;
+  font-size: 14px;
+  font-weight: 500;
+  transition: opacity 0.2s ease;
+}
+
+.github-star-banner:hover {
+  opacity: 0.9;
+}
+
 /* Reset and base styles */
 * {
   box-sizing: border-box;
@@ -11,7 +31,7 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background-color: #f8fafc;
+  background-color: var(--color-background);
 }
 
 #root {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,56 @@
 import { useState, useEffect } from 'react';
-import { Theme, Container, Flex, Text, Box } from '@radix-ui/themes';
+import { Theme, Container, Flex, Text, Box, DropdownMenu, IconButton } from '@radix-ui/themes';
+import { SunIcon, MoonIcon, DesktopIcon, CheckIcon } from '@radix-ui/react-icons';
 import { InvoiceForm, PDFPreview } from './components';
 import { generateFakeInvoice, generatePDFBlob, downloadPDF } from './utils';
 import type { InvoiceData, InvoiceItem, BankDetailsUpdate } from './types/invoice';
 import './App.css';
 
+type ThemePreference = 'system' | 'light' | 'dark';
+
+function getSystemTheme(): 'light' | 'dark' {
+  if (typeof window !== 'undefined' && window.matchMedia) {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+  return 'light';
+}
+
+function getStoredTheme(): ThemePreference {
+  if (typeof window !== 'undefined') {
+    const stored = localStorage.getItem('theme-preference');
+    if (stored === 'system' || stored === 'light' || stored === 'dark') {
+      return stored;
+    }
+  }
+  return 'system';
+}
+
 function App() {
   const [invoiceData, setInvoiceData] = useState<InvoiceData>(generateFakeInvoice());
   const [pdfBlob, setPdfBlob] = useState<Blob | null>(null);
+  const [themePreference, setThemePreference] = useState<ThemePreference>(getStoredTheme);
+  const [resolvedTheme, setResolvedTheme] = useState<'light' | 'dark'>(
+    themePreference === 'system' ? getSystemTheme() : themePreference
+  );
+
+  // Handle theme changes
+  useEffect(() => {
+    localStorage.setItem('theme-preference', themePreference);
+    
+    if (themePreference === 'system') {
+      setResolvedTheme(getSystemTheme());
+      
+      // Listen for system theme changes
+      const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+      const handleChange = (e: MediaQueryListEvent) => {
+        setResolvedTheme(e.matches ? 'dark' : 'light');
+      };
+      mediaQuery.addEventListener('change', handleChange);
+      return () => mediaQuery.removeEventListener('change', handleChange);
+    } else {
+      setResolvedTheme(themePreference);
+    }
+  }, [themePreference]);
 
   // Generate invoice on component mount
   useEffect(() => {
@@ -88,13 +131,51 @@ function App() {
   };
 
   return (
-    <Theme>
+    <Theme appearance={resolvedTheme}>
+      {/* GitHub Star Banner */}
+      <a 
+        href="https://github.com/Danilqa/sample-invoice-generator" 
+        target="_blank" 
+        rel="noopener noreferrer"
+        className="github-star-banner"
+      >
+        ⭐️ Support the project by giving it a star on Github
+      </a>
+      
       <Container size="4" style={{ height: '100%', padding: '20px', paddingBottom: 0 }}>
-        <Box mb="4">
-          <Text size="6" weight="bold">📄 Sample Invoice Generator</Text>
-          <br/>
-          <Text size="1">For development and testing purposes only.</Text>
-        </Box>
+        <Flex justify="between" align="start" mb="4">
+          <Box>
+            <Text size="6" weight="bold">Sample Invoice Generator</Text>
+            <br/>
+            <Text size="1">For development and testing purposes only.</Text>
+          </Box>
+          <DropdownMenu.Root>
+            <DropdownMenu.Trigger>
+              <IconButton variant="ghost" size="2" style={{ color: resolvedTheme === 'dark' ? 'white' : 'black' }}>
+                {themePreference === 'system' && <DesktopIcon width="18" height="18" />}
+                {themePreference === 'light' && <SunIcon width="18" height="18" />}
+                {themePreference === 'dark' && <MoonIcon width="18" height="18" />}
+              </IconButton>
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Content align="end">
+              <DropdownMenu.Item onClick={() => setThemePreference('system')}>
+                <DesktopIcon width="16" height="16" />
+                System
+                {themePreference === 'system' && <CheckIcon style={{ marginLeft: 'auto' }} />}
+              </DropdownMenu.Item>
+              <DropdownMenu.Item onClick={() => setThemePreference('light')}>
+                <SunIcon width="16" height="16" />
+                Light
+                {themePreference === 'light' && <CheckIcon style={{ marginLeft: 'auto' }} />}
+              </DropdownMenu.Item>
+              <DropdownMenu.Item onClick={() => setThemePreference('dark')}>
+                <MoonIcon width="16" height="16" />
+                Dark
+                {themePreference === 'dark' && <CheckIcon style={{ marginLeft: 'auto' }} />}
+              </DropdownMenu.Item>
+            </DropdownMenu.Content>
+          </DropdownMenu.Root>
+        </Flex>
         <Flex 
           direction={{ initial: 'column', md: 'row' }} 
           gap="4" 

--- a/src/components/InvoiceForm.tsx
+++ b/src/components/InvoiceForm.tsx
@@ -1,4 +1,5 @@
 import { Flex, Card, Text, Button, TextField, Separator, Grid, Box, Select } from '@radix-ui/themes';
+import { ChevronDownIcon, FileTextIcon, IdCardIcon, CubeIcon } from '@radix-ui/react-icons';
 import { useState, useEffect } from 'react';
 import type { InvoiceData, InvoiceItem, BankDetailsUpdate } from '../types/invoice';
 import { getBankDetailsByCurrency, generateRandomInvalidBankDetails } from '../utils/bankDetails';
@@ -220,7 +221,10 @@ export const InvoiceForm = ({ invoiceData, onGenerate, onDownload, pdfBlob, onUp
 
         <Separator />
 
-        <Text size="4" weight="bold">📋 Invoice Details</Text>
+        <Flex align="center" gap="2">
+          <FileTextIcon width="18" height="18" />
+          <Text size="4" weight="bold">Invoice Details</Text>
+        </Flex>
         <Grid columns={{ initial: "1", sm: "2" }} gap="3">
           <Box>
             <Text as="label" htmlFor="invoiceNumber" size="2" weight="bold">Invoice Number</Text>
@@ -258,7 +262,10 @@ export const InvoiceForm = ({ invoiceData, onGenerate, onDownload, pdfBlob, onUp
 
         <Separator />
 
-        <Text size="4" weight="bold">🏦 Bank Details</Text>
+        <Flex align="center" gap="2">
+          <IdCardIcon width="18" height="18" />
+          <Text size="4" weight="bold">Bank Details</Text>
+        </Flex>
         <Grid gap="3" columns="70px 1fr">
           <Box>
             <Flex direction="column" gap="2">
@@ -384,10 +391,15 @@ export const InvoiceForm = ({ invoiceData, onGenerate, onDownload, pdfBlob, onUp
               style={{ cursor: 'pointer' }}
               onClick={() => setIsItemsExpanded(!isItemsExpanded)}
             >
-              <Text size="4" weight="bold">📦 Invoice Items</Text>
-              <Text size="3" style={{ transform: isItemsExpanded ? 'rotate(180deg)' : 'rotate(0deg)', transition: 'transform 0.2s ease' }}>
-                ▼
-              </Text>
+              <Flex align="center" gap="2">
+                <CubeIcon width="18" height="18" />
+                <Text size="4" weight="bold">Invoice Items</Text>
+              </Flex>
+              <ChevronDownIcon 
+                width="20" 
+                height="20" 
+                style={{ transform: isItemsExpanded ? 'rotate(180deg)' : 'rotate(0deg)', transition: 'transform 0.2s ease' }} 
+              />
             </Flex>
             
             {isItemsExpanded && (


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds theme customization and a small promotional banner, plus minor UI polish.
> 
> - Implements `system/light/dark` theme preference with localStorage persistence and system color-scheme detection; applies via Radix `Theme` `appearance`
> - New dropdown in header with Radix icons (`SunIcon`, `MoonIcon`, `DesktopIcon`, `CheckIcon`) to switch themes
> - Adds GitHub star banner with new styles; body background now uses `var(--color-background)`
> - Replaces emoji section headers with Radix icons and chevron in `InvoiceForm`; minor layout tweaks
> - Adds `@radix-ui/react-icons` dependency
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c64435b750b627121d368ce6e2bdcfe17bc0b269. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->